### PR TITLE
ci: automatically purge old prereleases beyond the 5 most recent

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -192,3 +192,17 @@ jobs:
         if:  env.GITHUB_TOKEN != ''
         run: |
             gh release create ${{env.CURRENT_VERSION}} ./artifacts/nuget/*.*nupkg ./artifacts/portable/Codeuctivity.HtmlRendererCli.Portable.zip ./artifacts/windows/Codeuctivity.HtmlRendererCli.exe ./artifacts/linux/Codeuctivity.HtmlRendererCli-linux-x64 ./artifacts/macos/Codeuctivity.HtmlRendererCli-osx-x64 --prerelease --generate-notes
+
+      - name: Purge old prereleases
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.TOKEN }}
+        if:  env.GITHUB_TOKEN != ''
+        run: |
+            KEEP=5
+            gh release list --json tagName,isPrerelease,isDraft,publishedAt \
+              --jq "[.[] | select(.isPrerelease and (.isDraft | not))] | sort_by(.publishedAt) | reverse | .[$KEEP:] | .[].tagName" \
+              | while read -r tag; do
+                  echo "Deleting old prerelease $tag"
+                  gh release delete "$tag" --cleanup-tag --yes
+                done


### PR DESCRIPTION
## Summary
- `deployTest` creates a new GitHub prerelease on every push to `main` via `gh release create ... --prerelease`, with no cleanup step, so prereleases accumulate forever (23+ currently, going back to October).
- Adds a "Purge old prereleases" step that keeps the 5 most recent prereleases and deletes the rest along with their tags (`gh release delete --cleanup-tag`). Full releases (e.g. `4.0.529`, marked `Latest`) are excluded from the query and never touched.

## Test plan
- [ ] Merge and confirm the next push to `main` runs the purge step and trims the release list to 5 prereleases + full releases
- [ ] Spot-check that `4.0.529` (Latest) and other non-prerelease releases remain untouched